### PR TITLE
Keyboard Mapper simplification

### DIFF
--- a/device.go
+++ b/device.go
@@ -11,8 +11,14 @@ import (
 type K struct {
 	// Proc contains a filename where one might find keyboard details. In proc, usually
 	// - this differs for testing and, potentially, different OSes
-	Proc   string
-	Mapper Mapper
+	Proc string
+
+	Caps     bool
+	Shifted  bool
+	Alted    bool
+	Mappings []Mapping
+
+	LeftShift, RightShift, Alt, AltGr, CapsLock uint16
 }
 
 var (
@@ -32,12 +38,23 @@ func NewK(t string) (k K) {
 	}
 
 	k.Proc = procDefaultString
-	k.Mapper = NewMapper(mm)
+
+	// TODO: How would one ensure these *are* false at start up?
+	k.Caps = false
+	k.Shifted = false
+	k.Alted = false
+
+	k.Mappings = mm.Mappings()
+	k.LeftShift = mm.LeftShift()
+	k.RightShift = mm.RightShift()
+	k.Alt = mm.Alt()
+	k.AltGr = mm.AltGr()
+	k.CapsLock = mm.CapsLock()
 
 	return
 }
 
-func (k K) Lookup() (d string, err error) {
+func (k K) Path() (d string, err error) {
 	var proc []byte
 
 	proc, err = ioutil.ReadFile(k.Proc)
@@ -64,5 +81,7 @@ func (k K) Lookup() (d string, err error) {
 			break
 		}
 	}
+
+	d = fmt.Sprintf("/dev/input/%s", d)
 	return
 }

--- a/device_test.go
+++ b/device_test.go
@@ -12,14 +12,14 @@ func TestNewK(t *testing.T) {
 }
 
 func TestKBLookup(t *testing.T) {
-	k := K{"./fixtures/devices", Mapper{}}
+	k := K{"./fixtures/devices", false, false, false, []Mapping{}, 0, 0, 0, 0, 0}
 
-	kbd, err := k.Lookup()
+	kbd, err := k.Path()
 	if err != nil {
 		t.Errorf("Lookup() error: %q", err)
 	}
 
-	if kbd != "event4" {
+	if kbd != "/dev/input/event4" {
 		t.Errorf("Lookup() error: expected 'event4', received %q", kbd)
 	}
 }

--- a/device_test.go
+++ b/device_test.go
@@ -5,14 +5,14 @@ import (
 )
 
 func TestNewK(t *testing.T) {
-	k := NewK()
+	k := NewK("iso9995")
 	if k.Proc != "/proc/bus/input/devices" {
 		t.Errorf("NewK() error: expected '/proc/bus/input/devices', received %q", k.Proc)
 	}
 }
 
 func TestKBLookup(t *testing.T) {
-	k := K{"./fixtures/devices"}
+	k := K{"./fixtures/devices", Mapper{}}
 
 	kbd, err := k.Lookup()
 	if err != nil {

--- a/iso9995_test.go
+++ b/iso9995_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+    "testing"
+)
+
+func TestNewISO9995(t *testing.T) {
+    isokb := NewISO9995()
+    emptykb := ISO9995{}
+
+    if isokb != emptykb {
+        t.Errorf("NewISO9995() error: received %q", isokb)
+    }
+}
+
+func TestKeycodeValues(t *testing.T) {
+    i := ISO9995{}
+
+    for _,tv := range []struct{
+        name string
+        m func()uint16
+        value uint16
+    }{
+        {"CapsLock()", i.CapsLock, 58},
+        {"LeftShift()", i.LeftShift, 42},
+        {"RightShift()", i.RightShift, 54},
+        {"Alt()", i.Alt, 56},
+        {"AltGr()", i.AltGr, 100},
+    } {
+        t.Run(tv.name, func(t *testing.T) {
+            if tv.m() != tv.value {
+                t.Errorf("%s: expected %d, received %d", tv.name, tv.value, tv.m())
+            }
+        })
+    }
+}

--- a/iso9995_test.go
+++ b/iso9995_test.go
@@ -1,36 +1,36 @@
 package main
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestNewISO9995(t *testing.T) {
-    isokb := NewISO9995()
-    emptykb := ISO9995{}
+	isokb := NewISO9995()
+	emptykb := ISO9995{}
 
-    if isokb != emptykb {
-        t.Errorf("NewISO9995() error: received %q", isokb)
-    }
+	if isokb != emptykb {
+		t.Errorf("NewISO9995() error: received %q", isokb)
+	}
 }
 
 func TestKeycodeValues(t *testing.T) {
-    i := ISO9995{}
+	i := ISO9995{}
 
-    for _,tv := range []struct{
-        name string
-        m func()uint16
-        value uint16
-    }{
-        {"CapsLock()", i.CapsLock, 58},
-        {"LeftShift()", i.LeftShift, 42},
-        {"RightShift()", i.RightShift, 54},
-        {"Alt()", i.Alt, 56},
-        {"AltGr()", i.AltGr, 100},
-    } {
-        t.Run(tv.name, func(t *testing.T) {
-            if tv.m() != tv.value {
-                t.Errorf("%s: expected %d, received %d", tv.name, tv.value, tv.m())
-            }
-        })
-    }
+	for _, tv := range []struct {
+		name  string
+		m     func() uint16
+		value uint16
+	}{
+		{"CapsLock()", i.CapsLock, 58},
+		{"LeftShift()", i.LeftShift, 42},
+		{"RightShift()", i.RightShift, 54},
+		{"Alt()", i.Alt, 56},
+		{"AltGr()", i.AltGr, 100},
+	} {
+		t.Run(tv.name, func(t *testing.T) {
+			if tv.m() != tv.value {
+				t.Errorf("%s: expected %d, received %d", tv.name, tv.value, tv.m())
+			}
+		})
+	}
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 
 	evdev "github.com/gvalkov/golang-evdev"
@@ -17,12 +16,10 @@ var (
 
 func main() {
 	keyboard := NewK("iso9995")
-	kbdEvent, err := keyboard.Lookup()
+	kbd, err := keyboard.Path()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	kbd := fmt.Sprintf("/dev/input/%s", kbdEvent)
 
 	log.Println(kbd)
 
@@ -45,23 +42,23 @@ func main() {
 
 			if ievent.Value == 0 {
 				switch {
-				case scanCode == keyboard.Mapper.LeftShift || scanCode == keyboard.Mapper.RightShift:
-					keyboard.Mapper.ShiftOff()
-				case scanCode == keyboard.Mapper.Alt || scanCode == keyboard.Mapper.AltGr:
-					keyboard.Mapper.AltOff()
+				case scanCode == keyboard.LeftShift || scanCode == keyboard.RightShift:
+					keyboard.ShiftOff()
+				case scanCode == keyboard.Alt || scanCode == keyboard.AltGr:
+					keyboard.AltOff()
 				}
 			}
 
 			if ievent.Value == 1 {
 				switch {
-				case scanCode == keyboard.Mapper.LeftShift || scanCode == keyboard.Mapper.RightShift:
-					keyboard.Mapper.ShiftOn()
-				case scanCode == keyboard.Mapper.Alt || scanCode == keyboard.Mapper.AltGr:
-					keyboard.Mapper.AltOn()
-				case scanCode == keyboard.Mapper.CapsLock:
-					keyboard.Mapper.CapsLockFlip()
+				case scanCode == keyboard.LeftShift || scanCode == keyboard.RightShift:
+					keyboard.ShiftOn()
+				case scanCode == keyboard.Alt || scanCode == keyboard.AltGr:
+					keyboard.AltOn()
+				case scanCode == keyboard.CapsLock:
+					keyboard.CapsLockFlip()
 				default:
-					keyboard.Mapper.Print(scanCode)
+					keyboard.Print(scanCode)
 				}
 			}
 		}

--- a/mappings.go
+++ b/mappings.go
@@ -19,16 +19,6 @@ func (m Mapping) Empty() bool {
 	return m == Mapping{}
 }
 
-// Mapper contains logic for mapping codes to keys
-type Mapper struct {
-	Caps     bool
-	Shifted  bool
-	Alted    bool
-	Mappings []Mapping
-
-	LeftShift, RightShift, Alt, AltGr, CapsLock uint16
-}
-
 // MapManager contains a direct translation of Scancodes to keys
 type MapManager interface {
 	Mappings() []Mapping
@@ -39,40 +29,23 @@ type MapManager interface {
 	AltGr() uint16
 }
 
-// NewMapper returns a Mapper for mapping presses to values
-func NewMapper(mm MapManager) (m Mapper) {
-	// TODO: How would one ensure these *are* false at start up?
-	m.Caps = false
-	m.Shifted = false
-	m.Alted = false
-
-	m.Mappings = mm.Mappings()
-	m.LeftShift = mm.LeftShift()
-	m.RightShift = mm.RightShift()
-	m.Alt = mm.Alt()
-	m.AltGr = mm.AltGr()
-	m.CapsLock = mm.CapsLock()
-
-	return
-}
-
-func (m *Mapper) ShiftOn() {
+func (m *K) ShiftOn() {
 	m.Shifted = true
 }
 
-func (m *Mapper) ShiftOff() {
+func (m *K) ShiftOff() {
 	m.Shifted = false
 }
 
-func (m *Mapper) AltOn() {
+func (m *K) AltOn() {
 	m.Alted = true
 }
 
-func (m *Mapper) AltOff() {
+func (m *K) AltOff() {
 	m.Alted = false
 }
 
-func (m *Mapper) CapsLockFlip() {
+func (m *K) CapsLockFlip() {
 	if m.Caps {
 		m.Caps = false
 	} else {
@@ -80,7 +53,7 @@ func (m *Mapper) CapsLockFlip() {
 	}
 }
 
-func (m Mapper) Print(sc uint16) {
+func (m K) Print(sc uint16) {
 	var output string
 	mappedCode := m.Mappings[int(sc)]
 

--- a/mappings_test.go
+++ b/mappings_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+    "testing"
+)
+
+type TestKB struct {}
+func (t TestKB)Mappings() []Mapping {
+    return []Mapping{
+        {"a", "A", "A", "A"},
+        {"1", "1", "!", "1"},
+        {},
+    }
+}
+func (t TestKB)CapsLock()uint16{return 100}
+func (t TestKB)LeftShift()uint16{return 101}
+func (t TestKB)RightShift()uint16{return 102}
+func (t TestKB)Alt()uint16{return 103}
+func (t TestKB)AltGr()uint16{return 104}
+
+func TestMappingEmpty(t *testing.T) {
+    kb := TestKB{}
+
+    r := kb.Mappings()[2].Empty()
+    if !r {
+        t.Errorf("Empty(): expected true, received %q", r)
+    }
+}
+
+func TestShiftKey(t *testing.T) {
+    kb := TestKB{}
+
+    t.Run("ShiftOn()", func(t *testing.T) {
+        t.Run("When un-shifted", func(t *testing.T) {
+            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.ShiftOn()
+
+            if !k.Shifted {
+                t.Errorf("k.Shifted: expected false, received %q", k.Shifted)
+            }
+        })
+
+        t.Run("When shifted", func(t *testing.T) {
+            k := K{"", false, true, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.ShiftOn()
+
+            if !k.Shifted {
+                t.Errorf("k.Shifted: expected false, received %q", k.Shifted)
+            }
+        })
+    })
+
+    t.Run("ShiftOff()", func(t *testing.T) {
+        t.Run("When un-shifted", func(t *testing.T) {
+            k := K{"", false, true, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.ShiftOff()
+
+            if k.Shifted {
+                t.Errorf("k.Shifted: expected true, received %q", k.Shifted)
+            }
+        })
+
+        t.Run("When shifted", func(t *testing.T) {
+            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.ShiftOff()
+
+            if k.Shifted {
+                t.Errorf("k.Shifted: expected true, received %q", k.Shifted)
+            }
+        })
+    })
+}
+
+func TestAltKey(t *testing.T) {
+    kb := TestKB{}
+
+    t.Run("AltOn()", func(t *testing.T) {
+        t.Run("When un-alted", func(t *testing.T) {
+            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.AltOn()
+
+            if !k.Alted {
+                t.Errorf("k.Alted: expected true, received %q", k.Alted)
+            }
+        })
+
+        t.Run("When alted", func(t *testing.T) {
+            k := K{"", false, false, true, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.AltOn()
+
+            if !k.Alted {
+                t.Errorf("k.Alted: expected true, received %q", k.Alted)
+            }
+        })
+    })
+
+    t.Run("AltOff()", func(t *testing.T) {
+        t.Run("When un-alted", func(t *testing.T) {
+            k := K{"", false, false, true, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.AltOff()
+
+            if k.Alted {
+                t.Errorf("k.Alted: expected false, received %q", k.Alted)
+            }
+        })
+
+        t.Run("When alted", func(t *testing.T) {
+            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.AltOff()
+
+            if k.Alted {
+                t.Errorf("k.Alted: expected true, received %q", k.Alted)
+            }
+        })
+    })
+}
+
+func TestCapsLockKey(t *testing.T) {
+    kb := TestKB{}
+
+    t.Run("CapsLockFlip()", func(t *testing.T) {
+        t.Run("When off", func(t *testing.T) {
+            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.CapsLockFlip()
+
+            if !k.Caps {
+                t.Errorf("k.Caps: expected false, received %q", k.Caps)
+            }
+        })
+
+        t.Run("When on", func(t *testing.T) {
+            k := K{"", true, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+            k.CapsLockFlip()
+
+            if k.Caps {
+                t.Errorf("k.Caps: expected true, received %q", k.Caps)
+            }
+        })
+    })
+}

--- a/mappings_test.go
+++ b/mappings_test.go
@@ -1,140 +1,141 @@
 package main
 
 import (
-    "testing"
+	"testing"
 )
 
-type TestKB struct {}
-func (t TestKB)Mappings() []Mapping {
-    return []Mapping{
-        {"a", "A", "A", "A"},
-        {"1", "1", "!", "1"},
-        {},
-    }
+type TestKB struct{}
+
+func (t TestKB) Mappings() []Mapping {
+	return []Mapping{
+		{"a", "A", "A", "A"},
+		{"1", "1", "!", "1"},
+		{},
+	}
 }
-func (t TestKB)CapsLock()uint16{return 100}
-func (t TestKB)LeftShift()uint16{return 101}
-func (t TestKB)RightShift()uint16{return 102}
-func (t TestKB)Alt()uint16{return 103}
-func (t TestKB)AltGr()uint16{return 104}
+func (t TestKB) CapsLock() uint16   { return 100 }
+func (t TestKB) LeftShift() uint16  { return 101 }
+func (t TestKB) RightShift() uint16 { return 102 }
+func (t TestKB) Alt() uint16        { return 103 }
+func (t TestKB) AltGr() uint16      { return 104 }
 
 func TestMappingEmpty(t *testing.T) {
-    kb := TestKB{}
+	kb := TestKB{}
 
-    r := kb.Mappings()[2].Empty()
-    if !r {
-        t.Errorf("Empty(): expected true, received %q", r)
-    }
+	r := kb.Mappings()[2].Empty()
+	if !r {
+		t.Errorf("Empty(): expected true, received %q", r)
+	}
 }
 
 func TestShiftKey(t *testing.T) {
-    kb := TestKB{}
+	kb := TestKB{}
 
-    t.Run("ShiftOn()", func(t *testing.T) {
-        t.Run("When un-shifted", func(t *testing.T) {
-            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.ShiftOn()
+	t.Run("ShiftOn()", func(t *testing.T) {
+		t.Run("When un-shifted", func(t *testing.T) {
+			k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.ShiftOn()
 
-            if !k.Shifted {
-                t.Errorf("k.Shifted: expected false, received %q", k.Shifted)
-            }
-        })
+			if !k.Shifted {
+				t.Errorf("k.Shifted: expected false, received %q", k.Shifted)
+			}
+		})
 
-        t.Run("When shifted", func(t *testing.T) {
-            k := K{"", false, true, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.ShiftOn()
+		t.Run("When shifted", func(t *testing.T) {
+			k := K{"", false, true, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.ShiftOn()
 
-            if !k.Shifted {
-                t.Errorf("k.Shifted: expected false, received %q", k.Shifted)
-            }
-        })
-    })
+			if !k.Shifted {
+				t.Errorf("k.Shifted: expected false, received %q", k.Shifted)
+			}
+		})
+	})
 
-    t.Run("ShiftOff()", func(t *testing.T) {
-        t.Run("When un-shifted", func(t *testing.T) {
-            k := K{"", false, true, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.ShiftOff()
+	t.Run("ShiftOff()", func(t *testing.T) {
+		t.Run("When un-shifted", func(t *testing.T) {
+			k := K{"", false, true, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.ShiftOff()
 
-            if k.Shifted {
-                t.Errorf("k.Shifted: expected true, received %q", k.Shifted)
-            }
-        })
+			if k.Shifted {
+				t.Errorf("k.Shifted: expected true, received %q", k.Shifted)
+			}
+		})
 
-        t.Run("When shifted", func(t *testing.T) {
-            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.ShiftOff()
+		t.Run("When shifted", func(t *testing.T) {
+			k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.ShiftOff()
 
-            if k.Shifted {
-                t.Errorf("k.Shifted: expected true, received %q", k.Shifted)
-            }
-        })
-    })
+			if k.Shifted {
+				t.Errorf("k.Shifted: expected true, received %q", k.Shifted)
+			}
+		})
+	})
 }
 
 func TestAltKey(t *testing.T) {
-    kb := TestKB{}
+	kb := TestKB{}
 
-    t.Run("AltOn()", func(t *testing.T) {
-        t.Run("When un-alted", func(t *testing.T) {
-            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.AltOn()
+	t.Run("AltOn()", func(t *testing.T) {
+		t.Run("When un-alted", func(t *testing.T) {
+			k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.AltOn()
 
-            if !k.Alted {
-                t.Errorf("k.Alted: expected true, received %q", k.Alted)
-            }
-        })
+			if !k.Alted {
+				t.Errorf("k.Alted: expected true, received %q", k.Alted)
+			}
+		})
 
-        t.Run("When alted", func(t *testing.T) {
-            k := K{"", false, false, true, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.AltOn()
+		t.Run("When alted", func(t *testing.T) {
+			k := K{"", false, false, true, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.AltOn()
 
-            if !k.Alted {
-                t.Errorf("k.Alted: expected true, received %q", k.Alted)
-            }
-        })
-    })
+			if !k.Alted {
+				t.Errorf("k.Alted: expected true, received %q", k.Alted)
+			}
+		})
+	})
 
-    t.Run("AltOff()", func(t *testing.T) {
-        t.Run("When un-alted", func(t *testing.T) {
-            k := K{"", false, false, true, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.AltOff()
+	t.Run("AltOff()", func(t *testing.T) {
+		t.Run("When un-alted", func(t *testing.T) {
+			k := K{"", false, false, true, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.AltOff()
 
-            if k.Alted {
-                t.Errorf("k.Alted: expected false, received %q", k.Alted)
-            }
-        })
+			if k.Alted {
+				t.Errorf("k.Alted: expected false, received %q", k.Alted)
+			}
+		})
 
-        t.Run("When alted", func(t *testing.T) {
-            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.AltOff()
+		t.Run("When alted", func(t *testing.T) {
+			k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.AltOff()
 
-            if k.Alted {
-                t.Errorf("k.Alted: expected true, received %q", k.Alted)
-            }
-        })
-    })
+			if k.Alted {
+				t.Errorf("k.Alted: expected true, received %q", k.Alted)
+			}
+		})
+	})
 }
 
 func TestCapsLockKey(t *testing.T) {
-    kb := TestKB{}
+	kb := TestKB{}
 
-    t.Run("CapsLockFlip()", func(t *testing.T) {
-        t.Run("When off", func(t *testing.T) {
-            k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.CapsLockFlip()
+	t.Run("CapsLockFlip()", func(t *testing.T) {
+		t.Run("When off", func(t *testing.T) {
+			k := K{"", false, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.CapsLockFlip()
 
-            if !k.Caps {
-                t.Errorf("k.Caps: expected false, received %q", k.Caps)
-            }
-        })
+			if !k.Caps {
+				t.Errorf("k.Caps: expected false, received %q", k.Caps)
+			}
+		})
 
-        t.Run("When on", func(t *testing.T) {
-            k := K{"", true, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
-            k.CapsLockFlip()
+		t.Run("When on", func(t *testing.T) {
+			k := K{"", true, false, false, kb.Mappings(), 101, 102, 103, 104, 101}
+			k.CapsLockFlip()
 
-            if k.Caps {
-                t.Errorf("k.Caps: expected true, received %q", k.Caps)
-            }
-        })
-    })
+			if k.Caps {
+				t.Errorf("k.Caps: expected true, received %q", k.Caps)
+			}
+		})
+	})
 }


### PR DESCRIPTION
There is no fucking point in having mappers and devices and shit in separate files/ structs/ objects. It makes things overly complex and does weird things to coupling of things.

The dependency tree goes from:

keyboard --> mapper --> kb_model

to 

keyboard --> kb_model

which just seems nicer